### PR TITLE
- Bump macOS version for downstream NIO support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftLSP",
-    platforms: [.iOS(.v11), .tvOS(.v11), .macOS(.v10_12)],
+    platforms: [.iOS(.v11), .tvOS(.v11), .macOS(.v10_14)],
     products: [
         .library(
             name: "SwiftLSP",


### PR DESCRIPTION
Heya! Few PR's coming your way to bump some macOS version support. 10.14 instead of 10.15 or more, figured minimum update was preferred. Up next will be another to update Vapor directly in https://github.com/flowtoolz/LSPService.

Cheers!